### PR TITLE
Add modeline/multiplexer/colored-paren generation to base16 themes

### DIFF
--- a/src/macros.lisp
+++ b/src/macros.lisp
@@ -22,5 +22,18 @@
        (lem:syntax-variable-attribute :foreground ,(color :base08))
        (lem:syntax-type-attribute :foreground ,(color :base0A))
        (lem:syntax-builtin-attribute :foreground ,(color :base0C))
+
+       ;; Modeline
+       (lem:modeline-name-attribute :foreground ,(color :base09))
+       (lem:inactive-modeline-name-attribute :foreground ,(color :base03))
+       (lem:modeline-major-mode-attribute :foreground ,(color :base0D))
+       (lem:inactive-modeline-major-mode-attribute :foreground ,(color :base03))
+       (lem:modeline-minor-modes-attribute :foreground ,(color :base07))
+       (lem:inactive-modeline-minor-modes-attribute :foreground ,(color :base03))
+       (lem:modeline-position-attribute :foreground ,(color :base06) :background ,(color :base01))
+       (lem:inactive-modeline-position-attribute :foreground ,(color :base03) :background ,(color :base01))
+       (lem:modeline-posline-attribute :foreground ,(color :base00) :background ,(color :base05))
+       (lem:inactive-modeline-posline-attribute :foreground ,(color :base00) :background ,(color :base02))
+       
        ,@(loop :for (name color) :on colors :by #'cddr
                :collect (list name color)))))

--- a/src/macros.lisp
+++ b/src/macros.lisp
@@ -24,6 +24,8 @@
        (lem:syntax-builtin-attribute :foreground ,(color :base0C))
 
        ;; Modeline
+       (lem:modeline :background ,(color :base02) :foreground ,(color :base07))
+       (lem:modeline-inactive :background ,(color :base01) :foreground ,(color :base03))
        (lem:modeline-name-attribute :foreground ,(color :base09))
        (lem:inactive-modeline-name-attribute :foreground ,(color :base03))
        (lem:modeline-major-mode-attribute :foreground ,(color :base0D))

--- a/src/macros.lisp
+++ b/src/macros.lisp
@@ -22,7 +22,7 @@
        (lem:syntax-variable-attribute :foreground ,(color :base08))
        (lem:syntax-type-attribute :foreground ,(color :base0A))
        (lem:syntax-builtin-attribute :foreground ,(color :base0C))
-
+       
        ;; Modeline
        (lem:modeline :background ,(color :base02) :foreground ,(color :base07))
        (lem:modeline-inactive :background ,(color :base01) :foreground ,(color :base03))
@@ -36,6 +36,14 @@
        (lem:inactive-modeline-position-attribute :foreground ,(color :base03) :background ,(color :base01))
        (lem:modeline-posline-attribute :foreground ,(color :base00) :background ,(color :base05))
        (lem:inactive-modeline-posline-attribute :foreground ,(color :base00) :background ,(color :base02))
+
+       ;; Multiplexer
+       (lem/frame-multiplexer:frame-multiplexer-active-frame-name-attribute
+        :foreground ,(color :base01) :background ,(color :base0A) :bold t)
+       (lem/frame-multiplexer:frame-multiplexer-frame-name-attribute
+        :foreground ,(color :base01) :background ,(color :base04) :bold t)
+       (lem/frame-multiplexer:frame-multiplexer-background-attribute
+        :foreground ,(color :base0A) :background ,(color :base01))
        
        ,@(loop :for (name color) :on colors :by #'cddr
                :collect (list name color)))))

--- a/src/macros.lisp
+++ b/src/macros.lisp
@@ -44,6 +44,14 @@
         :foreground ,(color :base01) :background ,(color :base04) :bold t)
        (lem/frame-multiplexer:frame-multiplexer-background-attribute
         :foreground ,(color :base0A) :background ,(color :base01))
+
+       ;; Paren coloring
+       (lem-lisp-mode/paren-coloring:paren-color-1 :foreground ,(color :base08))
+       (lem-lisp-mode/paren-coloring:paren-color-2 :foreground ,(color :base09))
+       (lem-lisp-mode/paren-coloring:paren-color-3 :foreground ,(color :base0A))
+       (lem-lisp-mode/paren-coloring:paren-color-4 :foreground ,(color :base0B))
+       (lem-lisp-mode/paren-coloring:paren-color-5 :foreground ,(color :base0C))
+       (lem-lisp-mode/paren-coloring:paren-color-6 :foreground ,(color :base0D))
        
        ,@(loop :for (name color) :on colors :by #'cddr
                :collect (list name color)))))

--- a/src/themes.lisp
+++ b/src/themes.lisp
@@ -1367,6 +1367,27 @@
   :base0E "#9c6cd3"
   :base0F "#bb64a9")
 
+;; Scheme: everforest-dark
+;; Scheme author: Sainnhe Park (sainnhe@gmail.com)
+
+(define-base16-color-theme "everforest-dark"
+  :base00 "#2b3339"
+  :base01 "#323c41"
+  :base02 "#383f45"
+  :base03 "#868d80"
+  :base04 "#d3c6aa"
+  :base05 "#d3c6aa"
+  :base06 "#e9e8d2"
+  :base07 "#fff9e8"
+  :base08 "#7fbbb3"
+  :base09 "#d699b6"
+  :base0A "#83c092"
+  :base0B "#dbbc7f"
+  :base0C "#e69875"
+  :base0D "#a7c080"
+  :base0E "#e67e80"
+  :base0F "#d699b6")
+
 ;; Scheme: framer
 ;; Scheme author: Framer (Maintained by Jesse Hoyos)
 


### PR DESCRIPTION
This PR adds modeline, multiplexer, and colored-paren attributes to base16 themes. 

(also adds `everforest-dark`)